### PR TITLE
[FEAT] 예매 취소 기능 구현

### DIFF
--- a/src/features/user/components/BookingDetail/PosterSection.jsx
+++ b/src/features/user/components/BookingDetail/PosterSection.jsx
@@ -39,7 +39,7 @@ export function PosterSection({
                             <span className="text-sm text-gray-300">공연일</span>
                         </div>
                         <p className="font-bold text-white whitespace-nowrap">{formatDate(concertDate)}</p>
-                        <p className="text-sm text-gray-400">
+                        <p className="text-gray-300">
                             {formatTime(startTime)} - {formatTime(endTime)}
                         </p>
                     </div>

--- a/src/features/user/services/userService.js
+++ b/src/features/user/services/userService.js
@@ -55,4 +55,13 @@ export const userService = {
             throw new Error(error.message || '예매 상세 내역을 불러오는 중 오류가 발생했습니다.');
         }
     },
+
+    cancelBooking: async (bookingId) => {
+        try {
+            const response = await apiClient.delete(`/mypage/bookingDetail/cancel/${bookingId}`);
+            console.log('response : ', response);
+        } catch (error) {
+            throw new Error(error.message || '예매 취소 중 오류가 발생했습니다.');
+        }
+    },
 };

--- a/src/pages/mypage/BookingDetail.jsx
+++ b/src/pages/mypage/BookingDetail.jsx
@@ -97,27 +97,23 @@ export default function BookingDetail() {
         }
     };
 
+    // 예매 취소
     const handleCancelBooking = async () => {
-        showNotification('예매 취소 기능 구현 예정', NOTIFICATION_TYPE.ERROR);
-        setShowCancelConfirm(false);
-        return;
+        if (bookingDetail.bookingStatus === BOOKING_STATUS.CANCELED) {
+            showNotification('이미 취소된 예매입니다.', NOTIFICATION_TYPE.ERROR);
+            return;
+        }
 
-        // TODO. 구현 예정
-        // if (bookingDetail.bookingStatus === BOOKING_STATUS.CANCELED) {
-        //     showNotification('이미 취소된 예매입니다.', NOTIFICATION_TYPE.ERROR);
-        //     return;
-        // }
-
-        // setIsLoading(true);
-        // try {
-        //     await new Promise((resolve) => setTimeout(resolve, 1500));
-        //     showNotification('예매가 취소되었습니다.', NOTIFICATION_TYPE.SUCCESS);
-        //     setShowCancelConfirm(false);
-        // } catch (error) {
-        //     showNotification('예매 취소에 실패했습니다.', NOTIFICATION_TYPE.ERROR);
-        // } finally {
-        //     setIsLoading(false);
-        // }
+        setIsLoading(true);
+        try {
+            const result = await userService.cancelBooking(bookingDetail.bookingId);
+            showNotification('예매가 취소되었습니다.', NOTIFICATION_TYPE.SUCCESS);
+        } catch (error) {
+            showNotification(`${error}`, NOTIFICATION_TYPE.ERROR);
+        } finally {
+            setIsLoading(false);
+            setShowCancelConfirm(false);
+        }
     };
 
     const handleDownloadTicket = () => {


### PR DESCRIPTION
# 🎫 [예매 취소] 예매 취소 기능 구현

## 작업 내용
<!-- 이번 PR에서 구현한 기능(세부적인 기능 포함)을 간단히 설명해주세요 -->

* [x] 예매 취소 API 연동 구현
* [x] 예매 취소 기능 활성화 및 실제 처리 로직 적용
* [x] 예매 상세 화면 시간 표시 스타일 개선

## 주요 변경사항
<!-- 코드의 핵심 변경사항을 설명해주세요 -->

* **새로 추가된 파일**: 없음

* **수정된 파일**:
  - `src/features/user/services/userService.js`: 예매 취소 API 호출 함수 추가
  - `src/pages/mypage/BookingDetail.jsx`: 예매 취소 기능 구현 및 기존 TODO 코드 제거
  - `src/features/user/components/BookingDetail/PosterSection.jsx`: 시간 표시 텍스트 색상 개선

* **삭제된 파일**: 없음

### 세부 변경사항
- **userService.js**: `cancelBooking` 함수 추가하여 DELETE API 호출 처리
- **BookingDetail.jsx**: 
  - 임시 알림 메시지 제거 및 실제 API 호출 로직 구현
  - 예매 취소 후 성공/실패 처리 및 로딩 상태 관리
  - 주석 처리된 TODO 코드 정리
- **PosterSection.jsx**: 공연 시간 텍스트 색상을 `text-gray-400`에서 `text-gray-300`으로 변경하여 가독성 향상

## 보안 확인사항

* [x] 민감정보 환경변수 처리
* [x] 입력값 validation 어노테이션 적용
* [x] 에러 핸들링 시 내부 정보 노출 방지

## 테스트 확인사항

- [ ] 예매 취소 기능 정상 동작 테스트
- [ ] 이미 취소된 예매에 대한 중복 취소 방지 확인
- [ ] 예매 취소 후 UI 상태 업데이트 확인
- [ ] 에러 발생 시 사용자 친화적 메시지 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 예약 취소 기능이 구현되어, 사용자가 예약 상세 페이지에서 직접 예약을 취소할 수 있습니다.

* **Style**
  * 공연 시작 및 종료 시간 텍스트 색상이 더 밝은 회색으로 변경되었습니다.  
  * 해당 텍스트의 크기 스타일이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->