### PR TITLE
[콘서트 관리] Revert 진행 및 리뷰/기대평 수정 기능 버그 수정, 코드 포맷팅 적용

### DIFF
--- a/src/features/concert/components/ExpectationForm.jsx
+++ b/src/features/concert/components/ExpectationForm.jsx
@@ -259,41 +259,34 @@ const ExpectationForm = ({
   const handleSubmit = useCallback(
     async (event) => {
       event.preventDefault();
-
       // 모든 필드를 터치 상태로 설정 (에러 표시용)
       setTouched({
-        comment: true,
-        expectationRating: true,
+        title: true,
+        description: true,
+        rating: true,
         userNickname: true,
       });
-
       // 전체 폼 유효성 검증
       if (!validateForm()) {
         return;
       }
-
       // 비활성화 상태이거나 로딩 중이면 제출하지 않음
       if (disabled || loading) {
         return;
       }
-
       try {
         // 부모 컴포넌트의 제출 함수 호출
         if (onSubmit && typeof onSubmit === 'function') {
-          if (mode === 'edit' && initialData?.id) {
-            // 수정 모드: expectationId와 함께 전달
-            await onSubmit(initialData.id, formData);
-          } else {
-            // 작성 모드: 폼 데이터만 전달
-            await onSubmit(formData);
-          }
+          // 🔧 수정: 항상 formData만 전달하도록 변경
+          // 수정/작성 모드 구분은 부모 컴포넌트에서 처리
+          await onSubmit(formData);
         }
       } catch (error) {
         // 에러는 상위 컴포넌트에서 처리
-        console.error('기대평 제출 실패:', error);
+        console.error('리뷰 제출 실패:', error);
       }
     },
-    [formData, disabled, loading, validateForm, onSubmit, mode, initialData],
+    [formData, disabled, loading, validateForm, onSubmit],
   );
 
   /**

--- a/src/features/concert/components/ExpectationList.jsx
+++ b/src/features/concert/components/ExpectationList.jsx
@@ -55,6 +55,9 @@ const ExpectationList = ({
   onPageChange, // 페이지 변경 핸들러 (useExpectations.goToPage)
   onPageSizeChange, // 페이지 크기 변경 핸들러 (useExpectations.changePageSize)
   onRefresh, // 새로고침 핸들러 (useExpectations.refresh)
+  currentUserId, // 현재 사용자 ID
+  onEditClick, // 수정 버튼 클릭 핸들러
+  onDeleteClick, // 삭제 버튼 클릭 핸들러
 
   // ===== UI 제어 props =====
   showPagination = true, // 페이지네이션 표시 여부
@@ -622,6 +625,52 @@ const ExpectationList = ({
                 ? expectation.comment.substring(0, 150) + '...'
                 : expectation.comment}
             </p>
+            {/* 수정/삭제 버튼 (작성자만) */}
+            {currentUserId === expectation.userId && (
+              <div
+                style={{
+                  marginTop: '8px',
+                  display: 'flex',
+                  gap: '8px',
+                  justifyContent: 'flex-end',
+                }}
+              >
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEditClick?.(expectation);
+                  }}
+                  style={{
+                    padding: '4px 8px',
+                    backgroundColor: '#3b82f6',
+                    color: '#ffffff',
+                    border: 'none',
+                    borderRadius: '4px',
+                    fontSize: '12px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  ✏️ 수정
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDeleteClick?.(expectation);
+                  }}
+                  style={{
+                    padding: '4px 8px',
+                    backgroundColor: '#ef4444',
+                    color: '#ffffff',
+                    border: 'none',
+                    borderRadius: '4px',
+                    fontSize: '12px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  🗑️ 삭제
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/src/features/concert/hooks/useReviews.js
+++ b/src/features/concert/hooks/useReviews.js
@@ -1,216 +1,110 @@
 // src/features/concert/hooks/useReviews.js
 
-// React에서 제공하는 기본 훅들을 import
-// useState: 컴포넌트의 상태(데이터)를 관리하는 훅
-// useEffect: 컴포넌트가 렌더링된 후 특정 작업을 수행하는 훅 (API 호출 등)
-// useCallback: 함수를 메모이제이션(캐싱)해서 불필요한 재생성을 방지하는 훅
 import { useState, useEffect, useCallback } from 'react';
-
-// 우리가 만든 리뷰 서비스 import (실제 API 호출 로직이 들어있음)
 import { reviewService } from '../services/reviewService.js';
-
-// 리뷰 관련 타입과 기본값들 import
 import { ReviewDefaults } from '../types/review.js';
 
-/**
- * 리뷰(후기) 목록 관리를 위한 커스텀 React 훅
- *
- * 🎯 이 훅이 하는 일:
- * 1. 특정 콘서트의 리뷰 목록 상태 관리 (reviews 배열)
- * 2. API 호출 중인지 상태 관리 (loading boolean)
- * 3. 에러 발생 시 에러 상태 관리 (error 객체/메시지)
- * 4. 페이지네이션 상태 관리 (page, totalPages 등)
- * 5. 정렬 상태 관리 (sortBy, sortDir)
- * 6. 리뷰 목록을 가져오는 함수 제공 (fetchReviews)
- * 7. 리뷰 작성/수정/삭제 함수 제공
- * 8. 정렬 및 페이지 변경 함수 제공
- *
- * 🔄 사용 방법:
- * const { reviews, loading, error, fetchReviews, createReview } = useReviews(concertId);
- *
- * @param {number} concertId - 리뷰를 관리할 콘서트 ID (필수)
- * @returns {Object} 리뷰 관련 상태와 함수들이 담긴 객체
- */
 export const useReviews = (concertId) => {
-  // ===== 상태(State) 정의 =====
-  // React의 useState 훅을 사용해서 컴포넌트의 상태를 정의
-
-  // 리뷰 목록 데이터를 저장하는 상태
-  // 초기값: 빈 배열 []
   const [reviews, setReviews] = useState([]);
-
-  // API 호출 중인지 여부를 나타내는 상태
-  // 초기값: false (로딩 중이 아님)
   const [loading, setLoading] = useState(false);
-
-  // 에러 발생 시 에러 정보를 저장하는 상태
-  // 초기값: null (에러 없음)
   const [error, setError] = useState(null);
-
-  // 페이지네이션 관련 상태들
-  // 현재 페이지 번호 (0부터 시작)
   const [currentPage, setCurrentPage] = useState(0);
-
-  // 한 페이지당 보여줄 리뷰 개수 (기본값: 10개)
   const [pageSize, setPageSize] = useState(ReviewDefaults.pageSize);
-
-  // 전체 페이지 수 (API에서 받아옴)
   const [totalPages, setTotalPages] = useState(0);
-
-  // 전체 리뷰 개수 (API에서 받아옴)
   const [totalElements, setTotalElements] = useState(0);
-
-  // 정렬 관련 상태들
-  // 정렬 기준 필드 (createdAt, rating, title 등)
   const [sortBy, setSortBy] = useState(ReviewDefaults.sortBy);
-
-  // 정렬 방향 (asc: 오름차순, desc: 내림차순)
   const [sortDir, setSortDir] = useState(ReviewDefaults.sortDir);
-
-  // 개별 리뷰 작업 상태 (작성/수정/삭제 중인지)
   const [actionLoading, setActionLoading] = useState(false);
 
-  // ===== 함수 정의 =====
-
-  /**
-   * 리뷰 목록을 가져오는 함수
-   * useCallback으로 감싸서 불필요한 함수 재생성을 방지
-   *
-   * @param {Object} params - 조회 파라미터 (선택사항)
-   * @param {number} params.page - 가져올 페이지 번호 (기본값: currentPage)
-   * @param {number} params.size - 페이지 크기 (기본값: pageSize)
-   * @param {string} params.sortBy - 정렬 기준 (기본값: sortBy)
-   * @param {string} params.sortDir - 정렬 방향 (기본값: sortDir)
-   */
   const fetchReviews = useCallback(
     async (params = {}) => {
       try {
-        // concertId가 없으면 리뷰를 조회할 수 없음
         if (!concertId || concertId < 1) {
           throw new Error('유효한 콘서트 ID가 필요합니다.');
         }
 
-        // 로딩 시작: 사용자에게 "데이터 가져오는 중"임을 표시
         setLoading(true);
-
-        // 이전 에러 상태 초기화: 새로운 요청이므로 기존 에러 제거
         setError(null);
 
-        // 파라미터 기본값 설정 및 현재 상태와 병합
         const requestParams = {
-          concertId, // 콘서트 ID (필수)
-          page: params.page ?? currentPage, // 페이지 번호 (기본값: 현재 페이지)
-          size: params.size ?? pageSize, // 페이지 크기 (기본값: 현재 페이지 크기)
-          sortBy: params.sortBy ?? sortBy, // 정렬 기준 (기본값: 현재 정렬 기준)
-          sortDir: params.sortDir ?? sortDir, // 정렬 방향 (기본값: 현재 정렬 방향)
+          concertId,
+          page: params.page ?? currentPage,
+          size: params.size ?? pageSize,
+          sortBy: params.sortBy ?? sortBy,
+          sortDir: params.sortDir ?? sortDir,
         };
 
-        // 실제 API 호출: reviewService의 getConcertReviews 메서드 사용
-        // 백엔드에서 페이지네이션된 리뷰 데이터를 받아옴
         const response = await reviewService.getConcertReviews(requestParams);
 
-        // API 호출 성공 시 받아온 데이터로 상태 업데이트
         if (response && response.data) {
-          // 리뷰 목록 데이터 설정
           setReviews(response.data.content || []);
-
-          // 페이지네이션 정보 업데이트
-          setCurrentPage(response.data.number || 0); // 현재 페이지
-          setTotalPages(response.data.totalPages || 0); // 전체 페이지 수
-          setTotalElements(response.data.totalElements || 0); // 전체 리뷰 수
-          setPageSize(response.data.size || ReviewDefaults.pageSize); // 페이지 크기
-
-          // 요청한 정렬 정보로 상태 업데이트 (실제 사용된 파라미터로 동기화)
+          setCurrentPage(response.data.number || 0);
+          setTotalPages(response.data.totalPages || 0);
+          setTotalElements(response.data.totalElements || 0);
+          setPageSize(response.data.size || ReviewDefaults.pageSize);
           setSortBy(requestParams.sortBy);
           setSortDir(requestParams.sortDir);
 
-          // 개발/디버깅용 로그: 몇 개의 리뷰를 받았는지 확인
           console.info(
             `리뷰 목록 로드 완료: ${response.data.content?.length || 0}개 (콘서트 ID: ${concertId})`,
           );
         } else {
-          // API 응답은 성공했지만 데이터 형식이 예상과 다른 경우
           setReviews([]);
           setError('리뷰 데이터를 불러올 수 없습니다.');
         }
       } catch (err) {
-        // API 호출 실패 시 에러 처리
         console.error(`리뷰 목록 조회 실패 (콘서트 ID: ${concertId}):`, err);
-
-        // 사용자에게 보여줄 친화적인 에러 메시지 설정
         setError(err.message || '리뷰 목록을 불러오는 중 오류가 발생했습니다.');
-
-        // 에러 발생 시 빈 배열로 초기화
         setReviews([]);
       } finally {
-        // 성공/실패 상관없이 로딩 상태 해제
         setLoading(false);
       }
     },
     [concertId],
-  ); // 이 값들이 변경되면 함수 재생성
+  );
 
-  /**
-   * 새로운 리뷰를 작성하는 함수
-   *
-   * @param {import('../types/review.js').ReviewFormData} reviewData - 작성할 리뷰 데이터
-   * @returns {Promise<import('../types/review.js').Review>} 생성된 리뷰 정보
-   */
   const createReview = useCallback(
     async (reviewData) => {
       try {
-        // concertId 유효성 검증
         if (!concertId || concertId < 1) {
           throw new Error('유효한 콘서트 ID가 필요합니다.');
         }
 
-        // 개별 작업 로딩 시작 (리뷰 목록 로딩과 구분)
         setActionLoading(true);
-
-        // 에러 상태 초기화
         setError(null);
 
-        // 실제 API 호출: reviewService의 createReview 메서드 사용
         const response = await reviewService.createReview(
           concertId,
           reviewData,
         );
-
-        // 리뷰 작성 성공 시 목록 새로고침
-        // 첫 페이지로 이동해서 방금 작성한 리뷰를 보여줌 (최신순 정렬이므로)
         await fetchReviews({ page: 0 });
 
-        // 성공 로그
         console.info(
           `리뷰 작성 완료: "${reviewData.title}" (콘서트 ID: ${concertId})`,
         );
-
-        // 생성된 리뷰 정보 반환 (컴포넌트에서 추가 처리 가능)
         return response.data;
       } catch (err) {
         console.error(`리뷰 작성 실패 (콘서트 ID: ${concertId}):`, err);
-
-        // 에러를 상태에 설정하고 컴포넌트로도 전달
         setError(err.message || '리뷰 작성 중 오류가 발생했습니다.');
-        throw err; // 컴포넌트에서 에러 처리를 할 수 있도록 다시 throw
+        throw err;
       } finally {
-        // 개별 작업 로딩 해제
         setActionLoading(false);
       }
     },
     [concertId, fetchReviews],
-  ); // concertId와 fetchReviews가 변경되면 함수 재생성
+  );
 
   /**
-   * 기존 리뷰를 수정하는 함수
-   *
-   * @param {number} reviewId - 수정할 리뷰 ID
-   * @param {import('../types/review.js').ReviewFormData} reviewData - 수정할 데이터
-   * @returns {Promise<import('../types/review.js').Review>} 수정된 리뷰 정보
+   * 🔧 수정된 updateReview 함수 - 파라미터 순서 수정
    */
   const updateReview = useCallback(
     async (reviewId, reviewData) => {
       try {
+        // 🔍 디버깅: 파라미터 확인
+        console.log('🔍 useReviews.updateReview 호출됨:');
+        console.log('  - reviewId:', reviewId, typeof reviewId);
+        console.log('  - reviewData:', reviewData, typeof reviewData);
+
         // ID 파라미터 유효성 검증
         if (!concertId || concertId < 1) {
           throw new Error('유효한 콘서트 ID가 필요합니다.');
@@ -219,52 +113,41 @@ export const useReviews = (concertId) => {
           throw new Error('유효한 리뷰 ID가 필요합니다.');
         }
 
-        // 개별 작업 로딩 시작
+        // reviewData가 객체인지 확인
+        if (!reviewData || typeof reviewData !== 'object') {
+          throw new Error('유효한 리뷰 데이터가 필요합니다.');
+        }
+
         setActionLoading(true);
         setError(null);
 
-        // 실제 API 호출: reviewService의 updateReview 메서드 사용
+        // 🔧 수정: 올바른 순서로 파라미터 전달
         const response = await reviewService.updateReview(
           concertId,
           reviewId,
           reviewData,
         );
 
-        // 리뷰 수정 성공 시 현재 페이지 새로고침
-        // 페이지 위치는 유지하면서 수정된 내용만 반영
         await fetchReviews();
 
-        // 성공 로그
         console.info(
           `리뷰 수정 완료: ID ${reviewId} (콘서트 ID: ${concertId})`,
         );
-
-        // 수정된 리뷰 정보 반환
         return response.data;
       } catch (err) {
         console.error(`리뷰 수정 실패 (리뷰 ID: ${reviewId}):`, err);
-
-        // 에러를 상태에 설정하고 컴포넌트로도 전달
         setError(err.message || '리뷰 수정 중 오류가 발생했습니다.');
         throw err;
       } finally {
-        // 개별 작업 로딩 해제
         setActionLoading(false);
       }
     },
     [concertId, fetchReviews],
-  ); // concertId와 fetchReviews가 변경되면 함수 재생성
+  );
 
-  /**
-   * 리뷰를 삭제하는 함수
-   *
-   * @param {number} reviewId - 삭제할 리뷰 ID
-   * @returns {Promise<void>}
-   */
   const deleteReview = useCallback(
     async (reviewId) => {
       try {
-        // ID 파라미터 유효성 검증
         if (!concertId || concertId < 1) {
           throw new Error('유효한 콘서트 ID가 필요합니다.');
         }
@@ -272,50 +155,34 @@ export const useReviews = (concertId) => {
           throw new Error('유효한 리뷰 ID가 필요합니다.');
         }
 
-        // 개별 작업 로딩 시작
         setActionLoading(true);
         setError(null);
 
-        // 실제 API 호출: reviewService의 deleteReview 메서드 사용
         await reviewService.deleteReview(concertId, reviewId);
 
-        // 리뷰 삭제 성공 시 목록 새로고침
-        // 현재 페이지에 리뷰가 없으면 이전 페이지로 이동
         const currentReviewCount = reviews.length;
         if (currentReviewCount === 1 && currentPage > 0) {
-          // 현재 페이지의 마지막 리뷰를 삭제한 경우 이전 페이지로 이동
           await fetchReviews({ page: currentPage - 1 });
         } else {
-          // 현재 페이지에 다른 리뷰가 있으면 현재 페이지 새로고침
           await fetchReviews();
         }
 
-        // 성공 로그
         console.info(
           `리뷰 삭제 완료: ID ${reviewId} (콘서트 ID: ${concertId})`,
         );
       } catch (err) {
         console.error(`리뷰 삭제 실패 (리뷰 ID: ${reviewId}):`, err);
-
-        // 에러를 상태에 설정하고 컴포넌트로도 전달
         setError(err.message || '리뷰 삭제 중 오류가 발생했습니다.');
         throw err;
       } finally {
-        // 개별 작업 로딩 해제
         setActionLoading(false);
       }
     },
     [concertId, fetchReviews, reviews.length, currentPage],
-  ); // 의존하는 상태들
+  );
 
-  /**
-   * 페이지를 변경하는 함수
-   *
-   * @param {number} newPage - 이동할 페이지 번호
-   */
   const goToPage = useCallback(
     async (newPage) => {
-      // 페이지 번호 유효성 검증
       if (newPage < 0 || newPage >= totalPages) {
         console.warn(
           `유효하지 않은 페이지 번호: ${newPage} (범위: 0-${totalPages - 1})`,
@@ -323,151 +190,105 @@ export const useReviews = (concertId) => {
         return;
       }
 
-      // 현재 페이지와 같으면 불필요한 API 호출 방지
       if (newPage === currentPage) {
         console.info('같은 페이지이므로 API 호출을 건너뜁니다.');
         return;
       }
 
-      // 새로운 페이지의 리뷰 목록 가져오기
       await fetchReviews({ page: newPage });
     },
     [fetchReviews, totalPages, currentPage],
-  ); // 이 값들이 변경되면 함수 재생성
+  );
 
-  /**
-   * 정렬 방식을 변경하는 함수
-   *
-   * @param {string} newSortBy - 새로운 정렬 기준 (createdAt, rating, title)
-   * @param {string} newSortDir - 새로운 정렬 방향 (asc, desc)
-   */
   const changeSorting = useCallback(
     async (newSortBy, newSortDir = 'desc') => {
-      // 정렬 기준 유효성 검증
       const allowedSortFields = ['createdAt', 'rating', 'title'];
       if (!allowedSortFields.includes(newSortBy)) {
         console.warn(`유효하지 않은 정렬 기준: ${newSortBy}`);
         return;
       }
 
-      // 정렬 방향 유효성 검증
       const allowedSortDirections = ['asc', 'desc'];
       if (!allowedSortDirections.includes(newSortDir)) {
         console.warn(`유효하지 않은 정렬 방향: ${newSortDir}`);
         return;
       }
 
-      // 현재 정렬과 같으면 불필요한 API 호출 방지
       if (newSortBy === sortBy && newSortDir === sortDir) {
         console.info('같은 정렬 방식이므로 API 호출을 건너뜁니다.');
         return;
       }
-      console.log('changeSorting 호출됨:', newSortBy, newSortDir);
-      // 정렬 변경 시 첫 페이지부터 다시 조회
+
       await fetchReviews({
-        page: 0, // 첫 페이지로 이동
-        sortBy: newSortBy, // 새로운 정렬 기준
-        sortDir: newSortDir, // 새로운 정렬 방향
+        page: 0,
+        sortBy: newSortBy,
+        sortDir: newSortDir,
       });
     },
     [fetchReviews, sortBy, sortDir],
-  ); // 이 값들이 변경되면 함수 재생성
+  );
 
-  /**
-   * 페이지 크기를 변경하는 함수
-   *
-   * @param {number} newSize - 새로운 페이지 크기 (1-100)
-   */
   const changePageSize = useCallback(
     async (newSize) => {
-      // 페이지 크기 유효성 검증
       if (newSize < 1 || newSize > 100) {
         console.warn(`유효하지 않은 페이지 크기: ${newSize} (범위: 1-100)`);
         return;
       }
 
-      // 현재 페이지 크기와 같으면 불필요한 API 호출 방지
       if (newSize === pageSize) {
         console.info('같은 페이지 크기이므로 API 호출을 건너뜁니다.');
         return;
       }
 
-      // 페이지 크기 변경 시 첫 페이지부터 다시 조회
       await fetchReviews({
-        page: 0, // 첫 페이지로 이동
-        size: newSize, // 새로운 페이지 크기
+        page: 0,
+        size: newSize,
       });
     },
     [fetchReviews, pageSize],
-  ); // 이 값들이 변경되면 함수 재생성
+  );
 
-  // ===== 부수 효과(Side Effect) =====
-
-  /**
-   * concertId가 변경될 때마다 자동으로 리뷰 목록을 가져오는 효과
-   * 새로운 콘서트 페이지로 이동했을 때 해당 콘서트의 리뷰를 자동으로 로드
-   */
   useEffect(() => {
-    // concertId가 유효한 값일 때만 API 호출
     if (concertId && concertId > 0) {
-      // 새로운 콘서트의 리뷰 목록을 첫 페이지부터 기본 설정으로 가져오기
       fetchReviews({
-        page: 0, // 첫 페이지
-        size: ReviewDefaults.pageSize, // 기본 페이지 크기
-        sortBy: sortBy, // 현재 상태 유지
-        sortDir: sortDir, // 현재 상태 유지
+        page: 0,
+        size: ReviewDefaults.pageSize,
+        sortBy: sortBy,
+        sortDir: sortDir,
       });
 
-      // 개발자를 위한 로그: 어떤 콘서트의 리뷰를 가져오는지 확인
       console.info(`콘서트 ID ${concertId}의 리뷰 목록을 자동 로드합니다.`);
     }
-  }, [concertId]); // concertID가 변경되면 다시 실행
+  }, [concertId]);
 
-  // ===== 반환값 =====
-
-  /**
-   * 이 훅을 사용하는 컴포넌트에게 제공할 상태와 함수들
-   * 컴포넌트에서 구조 분해 할당으로 필요한 것만 가져다 쓸 수 있음
-   */
   return {
-    // 📊 데이터 상태
-    reviews, // 현재 로드된 리뷰 목록 배열
-    loading, // 리뷰 목록 로딩 중인지 여부 (true/false)
-    actionLoading, // 개별 작업 (작성/수정/삭제) 중인지 여부
-    error, // 에러 메시지 (문자열 또는 null)
-
-    // 📄 페이지네이션 상태
-    currentPage, // 현재 페이지 번호
-    totalPages, // 전체 페이지 수
-    totalElements, // 전체 리뷰 개수
-    pageSize, // 한 페이지당 리뷰 수
-
-    // 🔍 정렬 상태
-    sortBy, // 현재 정렬 기준
-    sortDir, // 현재 정렬 방향
-
-    // 🔧 액션 함수들 (컴포넌트에서 호출해서 상태 변경)
-    fetchReviews, // 리뷰 목록 새로고침
-    createReview, // 새 리뷰 작성
-    updateReview, // 기존 리뷰 수정
-    deleteReview, // 리뷰 삭제
-    goToPage, // 특정 페이지로 이동
-    changeSorting, // 정렬 방식 변경
-    changePageSize, // 페이지 크기 변경
-
-    // 🎛️ 편의 기능들
-    refresh: () => fetchReviews(), // 현재 설정으로 새로고침
-    hasNextPage: currentPage < totalPages - 1, // 다음 페이지 있는지 여부
-    hasPrevPage: currentPage > 0, // 이전 페이지 있는지 여부
-    isEmpty: reviews.length === 0 && !loading, // 리뷰가 비어있는지 (로딩 중이 아닐 때)
-    isFirstPage: currentPage === 0, // 첫 페이지인지 여부
-    isLastPage: currentPage === totalPages - 1, // 마지막 페이지인지 여부
-
-    // 정렬 관련 편의 기능
-    isSortedByDate: sortBy === 'createdAt', // 날짜순 정렬인지
-    isSortedByRating: sortBy === 'rating', // 평점순 정렬인지
-    isSortedByTitle: sortBy === 'title', // 제목순 정렬인지
-    isAscending: sortDir === 'asc', // 오름차순인지
-    isDescending: sortDir === 'desc', // 내림차순인지
+    reviews,
+    loading,
+    actionLoading,
+    error,
+    currentPage,
+    totalPages,
+    totalElements,
+    pageSize,
+    sortBy,
+    sortDir,
+    fetchReviews,
+    createReview,
+    updateReview,
+    deleteReview,
+    goToPage,
+    changeSorting,
+    changePageSize,
+    refresh: () => fetchReviews(),
+    hasNextPage: currentPage < totalPages - 1,
+    hasPrevPage: currentPage > 0,
+    isEmpty: reviews.length === 0 && !loading,
+    isFirstPage: currentPage === 0,
+    isLastPage: currentPage === totalPages - 1,
+    isSortedByDate: sortBy === 'createdAt',
+    isSortedByRating: sortBy === 'rating',
+    isSortedByTitle: sortBy === 'title',
+    isAscending: sortDir === 'asc',
+    isDescending: sortDir === 'desc',
   };
 };

--- a/src/features/concert/services/reviewService.js
+++ b/src/features/concert/services/reviewService.js
@@ -1,42 +1,64 @@
 // src/features/concert/services/reviewService.js
 
-// 프로젝트 공통 API 클라이언트 import (SuccessResponse 자동 처리, 인터셉터 설정 완료)
 import apiClient from '../../../shared/utils/apiClient.js';
 
 /**
- * 리뷰(후기) 관련 API 호출 서비스
- * 백엔드의 ReviewController와 ConcertController의 리뷰 관련 엔드포인트와 1:1 매핑
- *
- * 📋 지원하는 기능:
- * - 리뷰 목록 조회 (페이지네이션 + 정렬)
- * - 리뷰 상세 조회
- * - 리뷰 작성
- * - 리뷰 수정
- * - 리뷰 삭제
- *
- * 🔗 백엔드 엔드포인트:
- * - GET    /api/concerts/reviews/{concertId}?page=...&size=...&sortBy=...&sortDir=...
- * - GET    /api/concerts/{concertId}/reviews/{reviewId} (상세 조회)
- * - POST   /api/concerts/{concertId}/reviews
- * - PUT    /api/concerts/{concertId}/reviews/{reviewId}
- * - DELETE /api/concerts/{concertId}/reviews/{reviewId}
+ * 리뷰 데이터 유효성 검증 함수 (모듈 레벨)
  */
+const validateReviewData = (reviewData) => {
+  // 🔍 디버깅: 받은 데이터 확인
+  console.log('🔍 validateReviewData 받은 데이터:', reviewData);
+  console.log('🔍 title 값:', reviewData.title);
+  console.log('🔍 title 타입:', typeof reviewData.title);
+
+  // 제목 검증
+  if (!reviewData.title || reviewData.title.trim().length === 0) {
+    console.error('❌ 제목 검증 실패 - 값:', reviewData.title);
+    throw new Error('리뷰 제목은 필수입니다.');
+  }
+  if (reviewData.title.length > 100) {
+    throw new Error('리뷰 제목은 100자 이하여야 합니다.');
+  }
+
+  // 내용 검증
+  if (!reviewData.description || reviewData.description.trim().length === 0) {
+    console.error('❌ 내용 검증 실패 - 값:', reviewData.description);
+    throw new Error('리뷰 내용은 필수입니다.');
+  }
+  if (reviewData.description.length > 1000) {
+    throw new Error('리뷰 내용은 1000자 이하여야 합니다.');
+  }
+
+  // 평점 검증
+  if (!reviewData.rating || reviewData.rating < 1 || reviewData.rating > 5) {
+    console.error('❌ 평점 검증 실패 - 값:', reviewData.rating);
+    throw new Error('평점은 1 이상 5 이하여야 합니다.');
+  }
+  if (!Number.isInteger(reviewData.rating)) {
+    throw new Error('평점은 정수여야 합니다.');
+  }
+
+  // 닉네임 검증
+  if (!reviewData.userNickname || reviewData.userNickname.trim().length === 0) {
+    console.error('❌ 닉네임 검증 실패 - 값:', reviewData.userNickname);
+    throw new Error('작성자 닉네임은 필수입니다.');
+  }
+  if (reviewData.userNickname.length > 50) {
+    throw new Error('작성자 닉네임은 50자 이하여야 합니다.');
+  }
+
+  // 사용자 ID 검증
+  if (!reviewData.userId || reviewData.userId < 1) {
+    console.error('❌ 사용자ID 검증 실패 - 값:', reviewData.userId);
+    throw new Error('작성자 ID는 1 이상이어야 합니다.');
+  }
+
+  console.log('✅ 모든 검증 통과!');
+};
+
 export const reviewService = {
-  /**
-   * 특정 콘서트의 리뷰 목록을 페이지네이션과 정렬로 조회
-   * 백엔드: GET /api/concerts/reviews/{concertId}?page=...&size=...&sortBy=...&sortDir=...
-   *
-   * @param {import('../types/review.js').ReviewListParams} params - 조회 파라미터
-   * @param {number} params.concertId - 콘서트 ID (필수, 1 이상의 양수)
-   * @param {number} params.page - 페이지 번호 (0부터 시작, 기본값 0)
-   * @param {number} params.size - 페이지 크기 (1-100, 기본값 10)
-   * @param {string} params.sortBy - 정렬 기준 (createdAt/rating/title, 기본값 createdAt)
-   * @param {string} params.sortDir - 정렬 방향 (asc/desc, 기본값 desc)
-   * @returns {Promise<import('../types/concert.js').ApiResponse<import('../types/concert.js').PageResponse<import('../types/review.js').Review[]>>>}
-   */
   async getConcertReviews(params) {
     try {
-      // params에서 필요한 값들 추출 및 기본값 설정
       const {
         concertId,
         page = 0,
@@ -45,12 +67,10 @@ export const reviewService = {
         sortDir = 'desc',
       } = params;
 
-      // concertId 유효성 검증 - 필수값이고 양수여야 함
       if (!concertId || concertId < 1) {
         throw new Error('콘서트 ID는 1 이상의 양수여야 합니다.');
       }
 
-      // 페이지네이션 파라미터 유효성 검증
       if (page < 0) {
         throw new Error('페이지 번호는 0 이상이어야 합니다.');
       }
@@ -58,7 +78,6 @@ export const reviewService = {
         throw new Error('페이지 크기는 1 이상 100 이하여야 합니다.');
       }
 
-      // 정렬 기준 유효성 검증 (백엔드에서 허용하는 필드만)
       const allowedSortFields = ['createdAt', 'rating', 'title'];
       if (!allowedSortFields.includes(sortBy)) {
         throw new Error(
@@ -66,49 +85,27 @@ export const reviewService = {
         );
       }
 
-      // 정렬 방향 유효성 검증
       const allowedSortDirections = ['asc', 'desc'];
       if (!allowedSortDirections.includes(sortDir.toLowerCase())) {
         throw new Error('정렬 방향은 asc 또는 desc여야 합니다.');
       }
 
-      // API 요청: URL 경로에 concertId 포함, 나머지는 쿼리 파라미터로 전달
-      // 결과 예시: /api/concerts/reviews/123?page=0&size=10&sortBy=createdAt&sortDir=desc
       const response = await apiClient.get(`/concerts/reviews/${concertId}`, {
-        params: {
-          page, // 페이지 번호 (0부터 시작)
-          size, // 한 페이지당 리뷰 개수
-          sortBy, // 정렬 기준 필드
-          sortDir, // 정렬 방향
-        },
+        params: { page, size, sortBy, sortDir },
       });
 
-      // apiClient가 SuccessResponse를 자동 처리하므로 그대로 반환
-      // response.data 구조: { content: [], totalElements: number, totalPages: number, ... }
       return response;
     } catch (error) {
-      // 어떤 콘서트의 리뷰 조회에서 실패했는지 로그에 기록
       console.error(
         `리뷰 목록 조회 실패 (콘서트 ID: ${params.concertId}):`,
         error,
       );
-
-      // 에러를 컴포넌트로 전달하여 사용자에게 적절한 에러 메시지 표시
       throw error;
     }
   },
 
-  /**
-   * 특정 리뷰 상세 조회
-   * 백엔드: GET /api/concerts/{concertId}/reviews/{reviewId}
-   *
-   * @param {number} concertId - 콘서트 ID (필수, 1 이상의 양수)
-   * @param {number} reviewId - 리뷰 ID (필수, 1 이상의 양수)
-   * @returns {Promise<import('../types/concert.js').ApiResponse<import('../types/review.js').Review>>}
-   */
   async getReviewDetail(concertId, reviewId) {
     try {
-      // ID 파라미터 유효성 검증
       if (!concertId || concertId < 1) {
         throw new Error('콘서트 ID는 1 이상의 양수여야 합니다.');
       }
@@ -116,113 +113,43 @@ export const reviewService = {
         throw new Error('리뷰 ID는 1 이상의 양수여야 합니다.');
       }
 
-      // API 요청: URL 경로에 concertId와 reviewId 모두 포함
-      // 결과 예시: /api/concerts/123/reviews/456
       const response = await apiClient.get(
         `/concerts/${concertId}/reviews/${reviewId}`,
       );
-
-      // apiClient가 SuccessResponse를 자동 처리하므로 그대로 반환
-      // response.data 구조: Review 객체
       return response;
     } catch (error) {
-      // 어떤 리뷰 상세 조회에서 실패했는지 로그에 기록
       console.error(
         `리뷰 상세 조회 실패 (콘서트 ID: ${concertId}, 리뷰 ID: ${reviewId}):`,
         error,
       );
-
-      // 에러를 컴포넌트로 전달하여 사용자에게 적절한 에러 메시지 표시
       throw error;
-    }
-  },
-
-  /**
-   * 새로운 리뷰 작성
-   * 백엔드: POST /api/concerts/{concertId}/reviews
-   *
-   * @param {number} concertId - 콘서트 ID (URL 경로에 포함)
-   * @param {import('../types/review.js').ReviewFormData} reviewData - 작성할 리뷰 데이터
-   * @param {string} reviewData.title - 리뷰 제목 (필수, 최대 100자)
-   * @param {string} reviewData.description - 리뷰 내용 (필수, 최대 1000자)
-   * @param {number} reviewData.rating - 평점 (필수, 1-5점)
-   * @param {string} reviewData.userNickname - 작성자 닉네임 (필수, 최대 50자)
-   * @param {number} reviewData.userId - 작성자 ID (필수, 1 이상)
-   * @returns {Promise<import('../types/concert.js').ApiResponse<import('../types/review.js').Review>>}
-   */
-
-  /**
-   * 리뷰 데이터 유효성 검증
-   * @private
-   */
-  _validateReviewData(reviewData) {
-    // 제목 검증
-    if (!reviewData.title || reviewData.title.trim().length === 0) {
-      throw new Error('리뷰 제목은 필수입니다.');
-    }
-    if (reviewData.title.length > 100) {
-      throw new Error('리뷰 제목은 100자 이하여야 합니다.');
-    }
-
-    // 내용 검증
-    if (!reviewData.description || reviewData.description.trim().length === 0) {
-      throw new Error('리뷰 내용은 필수입니다.');
-    }
-    if (reviewData.description.length > 1000) {
-      throw new Error('리뷰 내용은 1000자 이하여야 합니다.');
-    }
-
-    // 평점 검증
-    if (!reviewData.rating || reviewData.rating < 1 || reviewData.rating > 5) {
-      throw new Error('평점은 1 이상 5 이하여야 합니다.');
-    }
-    if (!Number.isInteger(reviewData.rating)) {
-      throw new Error('평점은 정수여야 합니다.');
-    }
-
-    // 닉네임 검증
-    if (
-      !reviewData.userNickname ||
-      reviewData.userNickname.trim().length === 0
-    ) {
-      throw new Error('작성자 닉네임은 필수입니다.');
-    }
-    if (reviewData.userNickname.length > 50) {
-      throw new Error('작성자 닉네임은 50자 이하여야 합니다.');
-    }
-
-    // 사용자 ID 검증
-    if (!reviewData.userId || reviewData.userId < 1) {
-      throw new Error('작성자 ID는 1 이상이어야 합니다.');
     }
   },
 
   async createReview(concertId, reviewData) {
     try {
-      // concertId 유효성 검증
       if (!concertId || concertId < 1) {
         throw new Error('콘서트 ID는 1 이상의 양수여야 합니다.');
       }
-      // 리뷰 데이터 유효성 검증
-      this._validateReviewData(reviewData);
 
-      // 요청 바디 구성 - 백엔드 ReviewDTO 형식에 맞춤
+      // 🔍 디버깅: 생성 시 데이터 확인
+      console.log('🔍 createReview 받은 데이터:', reviewData);
+
+      validateReviewData(reviewData);
+
       const payload = {
-        title: reviewData.title.trim(), // 앞뒤 공백 제거
-        description: reviewData.description.trim(), // 앞뒤 공백 제거
-        rating: reviewData.rating, // 1-5 평점
-        userNickname: reviewData.userNickname.trim(), // 앞뒤 공백 제거
-        userId: reviewData.userId, // 작성자 ID
-        concertId: concertId, // URL과 일치성 확인용
+        title: reviewData.title.trim(),
+        description: reviewData.description.trim(),
+        rating: reviewData.rating,
+        userNickname: reviewData.userNickname.trim(),
+        userId: reviewData.userId,
+        concertId: concertId,
       };
 
-      // POST 요청: 두 번째 파라미터가 request body
       const response = await apiClient.post(
         `/concerts/${concertId}/reviews`,
         payload,
       );
-
-      // 성공 시 생성된 리뷰 정보 반환
       return response;
     } catch (error) {
       console.error(`리뷰 작성 실패 (콘서트 ID: ${concertId}):`, error);
@@ -230,18 +157,8 @@ export const reviewService = {
     }
   },
 
-  /**
-   * 기존 리뷰 수정
-   * 백엔드: PUT /api/concerts/{concertId}/reviews/{reviewId}
-   *
-   * @param {number} concertId - 콘서트 ID
-   * @param {number} reviewId - 수정할 리뷰 ID
-   * @param {import('../types/review.js').ReviewFormData} reviewData - 수정할 데이터
-   * @returns {Promise<import('../types/concert.js').ApiResponse<import('../types/review.js').Review>>}
-   */
   async updateReview(concertId, reviewId, reviewData) {
     try {
-      // ID 파라미터 유효성 검증
       if (!concertId || concertId < 1) {
         throw new Error('콘서트 ID는 1 이상의 양수여야 합니다.');
       }
@@ -249,72 +166,29 @@ export const reviewService = {
         throw new Error('리뷰 ID는 1 이상의 양수여야 합니다.');
       }
 
-      // 수정할 데이터 유효성 검증 (생성 시와 동일한 규칙)
+      // 🔍 디버깅: 수정 시 데이터 확인
+      console.log('🔍 updateReview 파라미터들:');
+      console.log('  - concertId:', concertId);
+      console.log('  - reviewId:', reviewId);
+      console.log('  - reviewData:', reviewData);
 
-      // 제목 검증
-      if (!reviewData.title || reviewData.title.trim().length === 0) {
-        throw new Error('리뷰 제목은 필수입니다.');
-      }
-      if (reviewData.title.length > 100) {
-        throw new Error('리뷰 제목은 100자 이하여야 합니다.');
-      }
+      validateReviewData(reviewData);
 
-      // 내용 검증
-      if (
-        !reviewData.description ||
-        reviewData.description.trim().length === 0
-      ) {
-        throw new Error('리뷰 내용은 필수입니다.');
-      }
-      if (reviewData.description.length > 1000) {
-        throw new Error('리뷰 내용은 1000자 이하여야 합니다.');
-      }
-
-      // 평점 검증
-      if (
-        !reviewData.rating ||
-        reviewData.rating < 1 ||
-        reviewData.rating > 5
-      ) {
-        throw new Error('평점은 1 이상 5 이하여야 합니다.');
-      }
-      if (!Number.isInteger(reviewData.rating)) {
-        throw new Error('평점은 정수여야 합니다.');
-      }
-
-      // 닉네임 검증
-      if (
-        !reviewData.userNickname ||
-        reviewData.userNickname.trim().length === 0
-      ) {
-        throw new Error('작성자 닉네임은 필수입니다.');
-      }
-      if (reviewData.userNickname.length > 50) {
-        throw new Error('작성자 닉네임은 50자 이하여야 합니다.');
-      }
-
-      // 사용자 ID 검증
-      if (!reviewData.userId || reviewData.userId < 1) {
-        throw new Error('작성자 ID는 1 이상이어야 합니다.');
-      }
-
-      // 수정 요청 바디 구성
       const payload = {
-        title: reviewData.title.trim(), // 수정된 리뷰 제목
-        description: reviewData.description.trim(), // 수정된 리뷰 내용
-        rating: reviewData.rating, // 수정된 평점
-        userNickname: reviewData.userNickname.trim(), // 수정된 닉네임 (보통 변경되지 않음)
-        userId: reviewData.userId, // 권한 확인용 사용자 ID
+        title: reviewData.title.trim(),
+        description: reviewData.description.trim(),
+        rating: reviewData.rating,
+        userNickname: reviewData.userNickname.trim(),
+        userId: reviewData.userId,
       };
 
-      // PUT 요청으로 기존 리뷰 전체 내용 교체
-      // URL에 concertId와 reviewId 모두 포함 (백엔드 권한 확인용)
+      console.log('🔍 전송할 payload:', payload);
+      console.log('🔍 요청 URL:', `/concerts/${concertId}/reviews/${reviewId}`);
+
       const response = await apiClient.put(
         `/concerts/${concertId}/reviews/${reviewId}`,
         payload,
       );
-
-      // 수정된 리뷰 정보 반환
       return response;
     } catch (error) {
       console.error(`리뷰 수정 실패 (리뷰 ID: ${reviewId}):`, error);
@@ -322,17 +196,8 @@ export const reviewService = {
     }
   },
 
-  /**
-   * 리뷰 삭제
-   * 백엔드: DELETE /api/concerts/{concertId}/reviews/{reviewId}
-   *
-   * @param {number} concertId - 콘서트 ID
-   * @param {number} reviewId - 삭제할 리뷰 ID
-   * @returns {Promise<import('../types/concert.js').ApiResponse<null>>}
-   */
   async deleteReview(concertId, reviewId) {
     try {
-      // ID 파라미터 유효성 검증
       if (!concertId || concertId < 1) {
         throw new Error('콘서트 ID는 1 이상의 양수여야 합니다.');
       }
@@ -340,13 +205,9 @@ export const reviewService = {
         throw new Error('리뷰 ID는 1 이상의 양수여야 합니다.');
       }
 
-      // DELETE 요청: request body 없음, URL에 필요한 ID들 포함
-      // 백엔드에서 사용자 권한 확인 후 삭제 처리
       const response = await apiClient.delete(
         `/concerts/${concertId}/reviews/${reviewId}`,
       );
-
-      // 삭제 성공 시 null 반환 (성공 메시지는 response.message에 포함)
       return response;
     } catch (error) {
       console.error(`리뷰 삭제 실패 (리뷰 ID: ${reviewId}):`, error);

--- a/src/features/seller/components/ConcertForm.jsx
+++ b/src/features/seller/components/ConcertForm.jsx
@@ -1,0 +1,881 @@
+import React, { useState, useEffect } from 'react';
+import {
+  X,
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  Image,
+  AlertCircle,
+  CheckCircle,
+} from 'lucide-react';
+
+/**
+ * ConcertForm.jsx
+ *
+ * 판매자용 콘서트 등록/수정 폼 컴포넌트
+ * - 백엔드 SellerConcertController의 API와 완전히 일치
+ * - POST /api/seller/concerts (생성)
+ * - PUT /api/seller/concerts/{concertId} (수정)
+ * - 백엔드 DTO 검증 규칙과 동일한 클라이언트 검증
+ */
+const ConcertForm = ({
+  isOpen,
+  onClose,
+  onSuccess,
+  concert = null, // 수정 모드일 때 기존 콘서트 데이터
+  sellerId,
+}) => {
+  // ====== 상태 관리 ======
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitSuccess, setSubmitSuccess] = useState('');
+
+  // 폼 데이터 - 백엔드 DTO와 완전히 일치
+  const [formData, setFormData] = useState({
+    // 필수 필드들 (SellerConcertCreateDTO)
+    title: '',
+    artist: '',
+    venueName: '',
+    concertDate: '',
+    startTime: '',
+    endTime: '',
+    totalSeats: '',
+    bookingStartDate: '',
+    bookingEndDate: '',
+
+    // 선택 필드들
+    description: '',
+    venueAddress: '',
+    minAge: 0,
+    maxTicketsPerUser: 4,
+    posterImageUrl: '',
+
+    // 수정 모드에서만 사용
+    status: 'SCHEDULED',
+  });
+
+  const isEditMode = !!concert;
+
+  // ====== 초기화 ======
+  useEffect(() => {
+    if (isEditMode && concert) {
+      // 수정 모드: 기존 데이터로 폼 초기화
+      setFormData({
+        title: concert.title || '',
+        artist: concert.artist || '',
+        description: concert.description || '',
+        venueName: concert.venueName || '',
+        venueAddress: concert.venueAddress || '',
+        concertDate: concert.concertDate || '',
+        startTime: concert.startTime || '',
+        endTime: concert.endTime || '',
+        totalSeats: concert.totalSeats?.toString() || '',
+        bookingStartDate: concert.bookingStartDate
+          ? new Date(concert.bookingStartDate).toISOString().slice(0, 16)
+          : '',
+        bookingEndDate: concert.bookingEndDate
+          ? new Date(concert.bookingEndDate).toISOString().slice(0, 16)
+          : '',
+        minAge: concert.minAge || 0,
+        maxTicketsPerUser: concert.maxTicketsPerUser || 4,
+        posterImageUrl: concert.posterImageUrl || '',
+        status: concert.status || 'SCHEDULED',
+      });
+    } else {
+      // 생성 모드: 기본값으로 초기화
+      setFormData({
+        title: '',
+        artist: '',
+        description: '',
+        venueName: '',
+        venueAddress: '',
+        concertDate: '',
+        startTime: '',
+        endTime: '',
+        totalSeats: '',
+        bookingStartDate: '',
+        bookingEndDate: '',
+        minAge: 0,
+        maxTicketsPerUser: 4,
+        posterImageUrl: '',
+        status: 'SCHEDULED',
+      });
+    }
+
+    setErrors({});
+    setSubmitError('');
+    setSubmitSuccess('');
+  }, [isEditMode, concert, isOpen]);
+
+  // ====== 입력 핸들러 ======
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+
+    // 해당 필드의 에러 클리어
+    if (errors[name]) {
+      setErrors((prev) => ({
+        ...prev,
+        [name]: '',
+      }));
+    }
+  };
+
+  // ====== 클라이언트 검증 (백엔드 DTO 검증과 동일) ======
+  const validateForm = () => {
+    const newErrors = {};
+
+    // 필수 문자열 필드 검증 (NotBlank)
+    if (!formData.title?.trim()) {
+      newErrors.title = '콘서트 제목은 필수입니다';
+    } else if (formData.title.trim().length > 100) {
+      newErrors.title = '콘서트 제목은 100자 이하여야 합니다';
+    }
+
+    if (!formData.artist?.trim()) {
+      newErrors.artist = '아티스트명은 필수입니다';
+    } else if (formData.artist.trim().length > 50) {
+      newErrors.artist = '아티스트명은 50자 이하여야 합니다';
+    }
+
+    if (!formData.venueName?.trim()) {
+      newErrors.venueName = '공연장명은 필수입니다';
+    } else if (formData.venueName.trim().length > 100) {
+      newErrors.venueName = '공연장명은 100자 이하여야 합니다';
+    }
+
+    // 선택 문자열 필드 길이 검증
+    if (formData.description && formData.description.length > 1000) {
+      newErrors.description = '콘서트 설명은 1000자 이하여야 합니다';
+    }
+
+    if (formData.venueAddress && formData.venueAddress.length > 200) {
+      newErrors.venueAddress = '공연장 주소는 200자 이하여야 합니다';
+    }
+
+    // 날짜 필드 검증 (NotNull, Future)
+    if (!formData.concertDate) {
+      newErrors.concertDate = '콘서트 날짜는 필수입니다';
+    } else {
+      const concertDate = new Date(formData.concertDate);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      if (concertDate <= today) {
+        newErrors.concertDate = '콘서트 날짜는 현재 날짜보다 이후여야 합니다';
+      }
+    }
+
+    // 시간 필드 검증 (NotNull)
+    if (!formData.startTime) {
+      newErrors.startTime = '시작 시간은 필수입니다';
+    }
+
+    if (!formData.endTime) {
+      newErrors.endTime = '종료 시간은 필수입니다';
+    }
+
+    // 시간 순서 검증
+    if (formData.startTime && formData.endTime) {
+      if (formData.endTime <= formData.startTime) {
+        newErrors.endTime = '종료 시간은 시작 시간보다 늦어야 합니다';
+      }
+    }
+
+    // 좌석 수 검증 (NotNull, Positive, Max)
+    if (!formData.totalSeats) {
+      newErrors.totalSeats = '총 좌석 수는 필수입니다';
+    } else {
+      const seats = parseInt(formData.totalSeats);
+      if (isNaN(seats) || seats <= 0) {
+        newErrors.totalSeats = '총 좌석 수는 양수여야 합니다';
+      } else if (seats > 100000) {
+        newErrors.totalSeats = '총 좌석 수는 100,000석 이하여야 합니다';
+      }
+    }
+
+    // 예매 일시 검증 (NotNull, Future)
+    if (!formData.bookingStartDate) {
+      newErrors.bookingStartDate = '예매 시작일시는 필수입니다';
+    } else {
+      const bookingStart = new Date(formData.bookingStartDate);
+      const now = new Date();
+
+      if (bookingStart <= now) {
+        newErrors.bookingStartDate =
+          '예매 시작일시는 현재 시간보다 이후여야 합니다';
+      }
+    }
+
+    if (!formData.bookingEndDate) {
+      newErrors.bookingEndDate = '예매 종료일시는 필수입니다';
+    } else {
+      const bookingEnd = new Date(formData.bookingEndDate);
+      const now = new Date();
+
+      if (bookingEnd <= now) {
+        newErrors.bookingEndDate =
+          '예매 종료일시는 현재 시간보다 이후여야 합니다';
+      }
+    }
+
+    // 예매 시간 순서 검증
+    if (formData.bookingStartDate && formData.bookingEndDate) {
+      const bookingStart = new Date(formData.bookingStartDate);
+      const bookingEnd = new Date(formData.bookingEndDate);
+
+      if (bookingEnd <= bookingStart) {
+        newErrors.bookingEndDate =
+          '예매 종료일시는 예매 시작일시보다 늦어야 합니다';
+      }
+    }
+
+    // 예매 기간과 공연 날짜 검증
+    if (formData.bookingEndDate && formData.concertDate && formData.startTime) {
+      const bookingEnd = new Date(formData.bookingEndDate);
+      const concertStart = new Date(
+        `${formData.concertDate}T${formData.startTime}`,
+      );
+
+      if (bookingEnd >= concertStart) {
+        newErrors.bookingEndDate = '예매 종료일시는 공연 시작 전이어야 합니다';
+      }
+    }
+
+    // 연령 제한 검증 (Min, Max)
+    const minAge = parseInt(formData.minAge);
+    if (isNaN(minAge) || minAge < 0) {
+      newErrors.minAge = '최소 연령은 0세 이상이어야 합니다';
+    } else if (minAge > 100) {
+      newErrors.minAge = '최소 연령은 100세 이하여야 합니다';
+    }
+
+    // 최대 티켓 수 검증 (Min, Max)
+    const maxTickets = parseInt(formData.maxTicketsPerUser);
+    if (isNaN(maxTickets) || maxTickets < 1) {
+      newErrors.maxTicketsPerUser =
+        '사용자당 최대 티켓 수는 1개 이상이어야 합니다';
+    } else if (maxTickets > 10) {
+      newErrors.maxTicketsPerUser =
+        '사용자당 최대 티켓 수는 10개 이하여야 합니다';
+    }
+
+    // 포스터 URL 패턴 검증
+    if (formData.posterImageUrl) {
+      const urlPattern = /^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i;
+      if (!urlPattern.test(formData.posterImageUrl)) {
+        newErrors.posterImageUrl =
+          '포스터 이미지 URL은 올바른 이미지 URL 형식이어야 합니다';
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // ====== API 호출 ======
+
+  /**
+   * 콘서트 생성
+   * POST /api/seller/concerts
+   */
+  const createConcert = async () => {
+    const params = new URLSearchParams({
+      sellerId: sellerId.toString(),
+    });
+
+    // 백엔드 SellerConcertCreateDTO에 맞는 데이터 구성
+    const createData = {
+      title: formData.title.trim(),
+      artist: formData.artist.trim(),
+      description: formData.description?.trim() || null,
+      venueName: formData.venueName.trim(),
+      venueAddress: formData.venueAddress?.trim() || null,
+      concertDate: formData.concertDate,
+      startTime: formData.startTime,
+      endTime: formData.endTime,
+      totalSeats: parseInt(formData.totalSeats),
+      bookingStartDate: formData.bookingStartDate,
+      bookingEndDate: formData.bookingEndDate,
+      minAge: parseInt(formData.minAge),
+      maxTicketsPerUser: parseInt(formData.maxTicketsPerUser),
+      posterImageUrl: formData.posterImageUrl?.trim() || null,
+    };
+
+    const response = await fetch(`/api/seller/concerts?${params}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(createData),
+    });
+
+    return response.json();
+  };
+
+  /**
+   * 콘서트 수정
+   * PUT /api/seller/concerts/{concertId}
+   */
+  const updateConcert = async () => {
+    const params = new URLSearchParams({
+      sellerId: sellerId.toString(),
+    });
+
+    // 백엔드 SellerConcertUpdateDTO에 맞는 데이터 구성 (부분 수정 지원)
+    const updateData = {};
+
+    // 변경된 필드만 포함 (null/undefined 값은 제외)
+    if (formData.title?.trim()) updateData.title = formData.title.trim();
+    if (formData.artist?.trim()) updateData.artist = formData.artist.trim();
+    if (formData.description !== undefined)
+      updateData.description = formData.description?.trim() || null;
+    if (formData.venueName?.trim())
+      updateData.venueName = formData.venueName.trim();
+    if (formData.venueAddress !== undefined)
+      updateData.venueAddress = formData.venueAddress?.trim() || null;
+    if (formData.concertDate) updateData.concertDate = formData.concertDate;
+    if (formData.startTime) updateData.startTime = formData.startTime;
+    if (formData.endTime) updateData.endTime = formData.endTime;
+    if (formData.totalSeats)
+      updateData.totalSeats = parseInt(formData.totalSeats);
+    if (formData.bookingStartDate)
+      updateData.bookingStartDate = formData.bookingStartDate;
+    if (formData.bookingEndDate)
+      updateData.bookingEndDate = formData.bookingEndDate;
+    if (formData.minAge !== undefined)
+      updateData.minAge = parseInt(formData.minAge);
+    if (formData.maxTicketsPerUser !== undefined)
+      updateData.maxTicketsPerUser = parseInt(formData.maxTicketsPerUser);
+    if (formData.status) updateData.status = formData.status;
+    if (formData.posterImageUrl !== undefined)
+      updateData.posterImageUrl = formData.posterImageUrl?.trim() || null;
+
+    const response = await fetch(
+      `/api/seller/concerts/${concert.concertId}?${params}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updateData),
+      },
+    );
+
+    return response.json();
+  };
+
+  // ====== 폼 제출 ======
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setLoading(true);
+    setSubmitError('');
+    setSubmitSuccess('');
+
+    try {
+      const result = isEditMode ? await updateConcert() : await createConcert();
+
+      if (result.success) {
+        setSubmitSuccess(
+          result.message ||
+            (isEditMode
+              ? '콘서트가 수정되었습니다.'
+              : '콘서트가 생성되었습니다.'),
+        );
+
+        // 성공 시 부모 컴포넌트에 알림
+        setTimeout(() => {
+          onSuccess && onSuccess(result.data);
+          onClose();
+        }, 1500);
+      } else {
+        setSubmitError(result.message || '처리 중 오류가 발생했습니다.');
+      }
+    } catch (error) {
+      setSubmitError('네트워크 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-2xl font-bold text-gray-900">
+            {isEditMode ? '콘서트 수정' : '콘서트 등록'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        {/* 성공/에러 메시지 */}
+        {submitSuccess && (
+          <div className="mx-6 mt-4 p-4 bg-green-50 border border-green-200 rounded-lg flex items-center gap-2">
+            <CheckCircle size={20} className="text-green-600" />
+            <span className="text-green-700">{submitSuccess}</span>
+          </div>
+        )}
+
+        {submitError && (
+          <div className="mx-6 mt-4 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2">
+            <AlertCircle size={20} className="text-red-600" />
+            <span className="text-red-700">{submitError}</span>
+          </div>
+        )}
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit} className="p-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* 기본 정보 섹션 */}
+            <div className="md:col-span-2">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">
+                기본 정보
+              </h3>
+            </div>
+
+            {/* 콘서트 제목 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                콘서트 제목 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                name="title"
+                value={formData.title}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.title ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="콘서트 제목을 입력하세요"
+                maxLength={100}
+              />
+              {errors.title && (
+                <p className="mt-1 text-sm text-red-600">{errors.title}</p>
+              )}
+            </div>
+
+            {/* 아티스트명 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                아티스트명 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                name="artist"
+                value={formData.artist}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.artist ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="아티스트명을 입력하세요"
+                maxLength={50}
+              />
+              {errors.artist && (
+                <p className="mt-1 text-sm text-red-600">{errors.artist}</p>
+              )}
+            </div>
+
+            {/* 콘서트 설명 */}
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                콘서트 설명
+              </label>
+              <textarea
+                name="description"
+                value={formData.description}
+                onChange={handleInputChange}
+                rows={3}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.description ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="콘서트에 대한 상세 설명을 입력하세요"
+                maxLength={1000}
+              />
+              {errors.description && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+
+            {/* 공연장 정보 섹션 */}
+            <div className="md:col-span-2 mt-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <MapPin size={20} />
+                공연장 정보
+              </h3>
+            </div>
+
+            {/* 공연장명 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                공연장명 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                name="venueName"
+                value={formData.venueName}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.venueName ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="공연장명을 입력하세요"
+                maxLength={100}
+              />
+              {errors.venueName && (
+                <p className="mt-1 text-sm text-red-600">{errors.venueName}</p>
+              )}
+            </div>
+
+            {/* 공연장 주소 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                공연장 주소
+              </label>
+              <input
+                type="text"
+                name="venueAddress"
+                value={formData.venueAddress}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.venueAddress ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="공연장 주소를 입력하세요"
+                maxLength={200}
+              />
+              {errors.venueAddress && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.venueAddress}
+                </p>
+              )}
+            </div>
+
+            {/* 일시 정보 섹션 */}
+            <div className="md:col-span-2 mt-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <Calendar size={20} />
+                일시 정보
+              </h3>
+            </div>
+
+            {/* 공연 날짜 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                공연 날짜 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="date"
+                name="concertDate"
+                value={formData.concertDate}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.concertDate ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.concertDate && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.concertDate}
+                </p>
+              )}
+            </div>
+
+            {/* 총 좌석 수 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                총 좌석 수 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                name="totalSeats"
+                value={formData.totalSeats}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.totalSeats ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="총 좌석 수를 입력하세요"
+                min={1}
+                max={100000}
+              />
+              {errors.totalSeats && (
+                <p className="mt-1 text-sm text-red-600">{errors.totalSeats}</p>
+              )}
+            </div>
+
+            {/* 시작 시간 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                시작 시간 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="time"
+                name="startTime"
+                value={formData.startTime}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.startTime ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.startTime && (
+                <p className="mt-1 text-sm text-red-600">{errors.startTime}</p>
+              )}
+            </div>
+
+            {/* 종료 시간 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                종료 시간 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="time"
+                name="endTime"
+                value={formData.endTime}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.endTime ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.endTime && (
+                <p className="mt-1 text-sm text-red-600">{errors.endTime}</p>
+              )}
+            </div>
+
+            {/* 예매 정보 섹션 */}
+            <div className="md:col-span-2 mt-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <Clock size={20} />
+                예매 정보
+              </h3>
+            </div>
+
+            {/* 예매 시작일시 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                예매 시작일시 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                name="bookingStartDate"
+                value={formData.bookingStartDate}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.bookingStartDate ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.bookingStartDate && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.bookingStartDate}
+                </p>
+              )}
+            </div>
+
+            {/* 예매 종료일시 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                예매 종료일시 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                name="bookingEndDate"
+                value={formData.bookingEndDate}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.bookingEndDate ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.bookingEndDate && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.bookingEndDate}
+                </p>
+              )}
+            </div>
+
+            {/* 추가 설정 섹션 */}
+            <div className="md:col-span-2 mt-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <Users size={20} />
+                추가 설정
+              </h3>
+            </div>
+
+            {/* 최소 연령 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                최소 연령 제한
+              </label>
+              <input
+                type="number"
+                name="minAge"
+                value={formData.minAge}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.minAge ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="최소 연령을 입력하세요"
+                min={0}
+                max={100}
+              />
+              {errors.minAge && (
+                <p className="mt-1 text-sm text-red-600">{errors.minAge}</p>
+              )}
+              <p className="mt-1 text-xs text-gray-500">
+                0세는 연령 제한 없음을 의미합니다
+              </p>
+            </div>
+
+            {/* 사용자당 최대 티켓 수 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                사용자당 최대 구매 티켓 수
+              </label>
+              <input
+                type="number"
+                name="maxTicketsPerUser"
+                value={formData.maxTicketsPerUser}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.maxTicketsPerUser
+                    ? 'border-red-300'
+                    : 'border-gray-300'
+                }`}
+                placeholder="최대 구매 가능 티켓 수"
+                min={1}
+                max={10}
+              />
+              {errors.maxTicketsPerUser && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.maxTicketsPerUser}
+                </p>
+              )}
+            </div>
+
+            {/* 수정 모드에서만 상태 선택 */}
+            {isEditMode && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  콘서트 상태
+                </label>
+                <select
+                  name="status"
+                  value={formData.status}
+                  onChange={handleInputChange}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="SCHEDULED">예정됨</option>
+                  <option value="ON_SALE">예매중</option>
+                  <option value="SOLD_OUT">매진</option>
+                  <option value="CANCELLED">취소됨</option>
+                  <option value="COMPLETED">완료됨</option>
+                </select>
+                <p className="mt-1 text-xs text-gray-500">
+                  상태 변경 시 신중하게 선택해주세요
+                </p>
+              </div>
+            )}
+
+            {/* 포스터 이미지 섹션 */}
+            <div className="md:col-span-2 mt-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <Image size={20} />
+                포스터 이미지
+              </h3>
+            </div>
+
+            {/* 포스터 이미지 URL */}
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                포스터 이미지 URL
+              </label>
+              <input
+                type="url"
+                name="posterImageUrl"
+                value={formData.posterImageUrl}
+                onChange={handleInputChange}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  errors.posterImageUrl ? 'border-red-300' : 'border-gray-300'
+                }`}
+                placeholder="https://example.com/poster.jpg"
+              />
+              {errors.posterImageUrl && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.posterImageUrl}
+                </p>
+              )}
+              <p className="mt-1 text-xs text-gray-500">
+                지원 형식: jpg, jpeg, png, gif, webp
+              </p>
+
+              {/* 포스터 미리보기 */}
+              {formData.posterImageUrl && !errors.posterImageUrl && (
+                <div className="mt-4">
+                  <p className="text-sm font-medium text-gray-700 mb-2">
+                    미리보기
+                  </p>
+                  <div className="w-32 h-48 border border-gray-300 rounded-lg overflow-hidden">
+                    <img
+                      src={formData.posterImageUrl}
+                      alt="포스터 미리보기"
+                      className="w-full h-full object-cover"
+                      onError={(e) => {
+                        e.target.style.display = 'none';
+                        e.target.nextSibling.style.display = 'flex';
+                      }}
+                    />
+                    <div
+                      className="w-full h-full bg-gray-100 flex items-center justify-center text-gray-500 text-sm"
+                      style={{ display: 'none' }}
+                    >
+                      이미지 로드 실패
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 폼 액션 버튼들 */}
+          <div className="flex justify-end gap-4 mt-8 pt-6 border-t border-gray-200">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+              disabled={loading}
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              {loading && (
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+              )}
+              {loading ? '처리 중...' : isEditMode ? '수정하기' : '등록하기'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ConcertForm;

--- a/src/features/seller/components/SellerConcertList.jsx
+++ b/src/features/seller/components/SellerConcertList.jsx
@@ -1,0 +1,606 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Plus,
+  Edit,
+  Trash2,
+  Image,
+  Calendar,
+  MapPin,
+  Users,
+  Clock,
+  Search,
+  Filter,
+  RefreshCw,
+} from 'lucide-react';
+
+/**
+ * SellerConcertList.jsx
+ *
+ * 판매자용 콘서트 목록 관리 컴포넌트
+ * - 백엔드 SellerConcertController의 API와 완전히 일치
+ * - 페이징, 정렬, 필터링 기능 제공
+ * - 콘서트 생성, 수정, 삭제, 상태 관리
+ * - 포스터 이미지 업데이트 기능
+ */
+const SellerConcertList = () => {
+  // ====== 상태 관리 ======
+  const [concerts, setConcerts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // 페이징 상태 (BE와 동일한 기본값)
+  const [pagination, setPagination] = useState({
+    page: 0, // BE: defaultValue = "0"
+    size: 10, // BE: defaultValue = "10"
+    totalElements: 0,
+    totalPages: 0,
+    first: true,
+    last: false,
+  });
+
+  // 정렬 상태 (BE ALLOWED_SORT_FIELDS와 일치)
+  const [sorting, setSorting] = useState({
+    sortBy: 'createdAt', // BE: defaultValue = "createdAt"
+    sortDir: 'desc', // BE: defaultValue = "desc"
+  });
+
+  // 필터 상태
+  const [filters, setFilters] = useState({
+    status: 'ALL', // 전체, 또는 특정 상태
+    searchKeyword: '',
+  });
+
+  // 판매자 ID (실제로는 로그인 사용자 정보에서 가져와야 함)
+  const [sellerId] = useState(100); // 예시용 하드코딩
+
+  // 모달 상태
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [selectedConcert, setSelectedConcert] = useState(null);
+
+  // ====== BE API 호출 함수들 ======
+
+  /**
+   * 판매자 콘서트 목록 조회
+   * GET /api/seller/concerts
+   */
+  const fetchConcerts = async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        sellerId: sellerId.toString(),
+        page: pagination.page.toString(),
+        size: pagination.size.toString(),
+        sortBy: sorting.sortBy,
+        sortDir: sorting.sortDir,
+      });
+
+      const response = await fetch(`/api/seller/concerts?${params}`);
+      const result = await response.json();
+
+      if (result.success) {
+        setConcerts(result.data.content);
+        setPagination((prev) => ({
+          ...prev,
+          totalElements: result.data.totalElements,
+          totalPages: result.data.totalPages,
+          first: result.data.first,
+          last: result.data.last,
+        }));
+      } else {
+        setError(result.message);
+      }
+    } catch (err) {
+      setError('콘서트 목록을 불러오는데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  /**
+   * 상태별 콘서트 조회
+   * GET /api/seller/concerts/status
+   */
+  const fetchConcertsByStatus = async (status) => {
+    if (status === 'ALL') {
+      fetchConcerts();
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        sellerId: sellerId.toString(),
+        status: status,
+      });
+
+      const response = await fetch(`/api/seller/concerts/status?${params}`);
+      const result = await response.json();
+
+      if (result.success) {
+        setConcerts(result.data);
+        // 상태별 조회는 페이징이 없으므로 리셋
+        setPagination((prev) => ({
+          ...prev,
+          totalElements: result.data.length,
+          totalPages: 1,
+          first: true,
+          last: true,
+        }));
+      } else {
+        setError(result.message);
+      }
+    } catch (err) {
+      setError('콘서트 목록을 불러오는데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  /**
+   * 콘서트 삭제 (취소 처리)
+   * DELETE /api/seller/concerts/{concertId}
+   */
+  const deleteConcert = async (concertId) => {
+    if (!confirm('정말로 이 콘서트를 취소하시겠습니까?')) return;
+
+    try {
+      const params = new URLSearchParams({
+        sellerId: sellerId.toString(),
+      });
+
+      const response = await fetch(
+        `/api/seller/concerts/${concertId}?${params}`,
+        {
+          method: 'DELETE',
+        },
+      );
+
+      const result = await response.json();
+
+      if (result.success) {
+        alert('콘서트가 취소되었습니다.');
+        fetchConcerts(); // 목록 새로고침
+      } else {
+        alert(result.message);
+      }
+    } catch (err) {
+      alert('콘서트 취소에 실패했습니다.');
+    }
+  };
+
+  // ====== 이벤트 핸들러들 ======
+
+  const handlePageChange = (newPage) => {
+    setPagination((prev) => ({ ...prev, page: newPage }));
+  };
+
+  const handleSizeChange = (newSize) => {
+    setPagination((prev) => ({ ...prev, page: 0, size: newSize }));
+  };
+
+  const handleSortChange = (field) => {
+    setSorting((prev) => ({
+      sortBy: field,
+      sortDir: prev.sortBy === field && prev.sortDir === 'asc' ? 'desc' : 'asc',
+    }));
+  };
+
+  const handleStatusFilter = (status) => {
+    setFilters((prev) => ({ ...prev, status }));
+    setPagination((prev) => ({ ...prev, page: 0 })); // 첫 페이지로 리셋
+  };
+
+  // ====== useEffect - 데이터 로딩 ======
+  useEffect(() => {
+    if (filters.status === 'ALL') {
+      fetchConcerts();
+    } else {
+      fetchConcertsByStatus(filters.status);
+    }
+  }, [
+    pagination.page,
+    pagination.size,
+    sorting.sortBy,
+    sorting.sortDir,
+    filters.status,
+  ]);
+
+  // ====== 상태별 스타일 및 텍스트 ======
+  const getStatusBadge = (status) => {
+    const statusConfig = {
+      SCHEDULED: { color: 'bg-blue-100 text-blue-800', text: '예정됨' },
+      ON_SALE: { color: 'bg-green-100 text-green-800', text: '예매중' },
+      SOLD_OUT: { color: 'bg-red-100 text-red-800', text: '매진' },
+      CANCELLED: { color: 'bg-gray-100 text-gray-800', text: '취소됨' },
+      COMPLETED: { color: 'bg-purple-100 text-purple-800', text: '완료됨' },
+    };
+
+    const config = statusConfig[status] || statusConfig.SCHEDULED;
+    return (
+      <span
+        className={`px-2 py-1 rounded-full text-xs font-medium ${config.color}`}
+      >
+        {config.text}
+      </span>
+    );
+  };
+
+  const formatDate = (dateString) => {
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const formatDateTime = (dateTimeString) => {
+    return new Date(dateTimeString).toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  // ====== 렌더링 ======
+  return (
+    <div className="p-6 bg-gray-50 min-h-screen">
+      {/* 헤더 섹션 */}
+      <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
+        <div className="flex justify-between items-center mb-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">콘서트 관리</h1>
+            <p className="text-gray-600 mt-1">
+              등록한 콘서트를 관리하고 편집할 수 있습니다
+            </p>
+          </div>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors"
+          >
+            <Plus size={20} />
+            콘서트 등록
+          </button>
+        </div>
+
+        {/* 필터 및 검색 */}
+        <div className="flex flex-wrap gap-4 items-center">
+          {/* 상태 필터 */}
+          <div className="flex gap-2">
+            {[
+              'ALL',
+              'SCHEDULED',
+              'ON_SALE',
+              'SOLD_OUT',
+              'CANCELLED',
+              'COMPLETED',
+            ].map((status) => (
+              <button
+                key={status}
+                onClick={() => handleStatusFilter(status)}
+                className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                  filters.status === status
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                }`}
+              >
+                {status === 'ALL'
+                  ? '전체'
+                  : status === 'SCHEDULED'
+                    ? '예정됨'
+                    : status === 'ON_SALE'
+                      ? '예매중'
+                      : status === 'SOLD_OUT'
+                        ? '매진'
+                        : status === 'CANCELLED'
+                          ? '취소됨'
+                          : '완료됨'}
+              </button>
+            ))}
+          </div>
+
+          {/* 새로고침 버튼 */}
+          <button
+            onClick={() => fetchConcerts()}
+            className="p-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
+            title="새로고침"
+          >
+            <RefreshCw size={18} />
+          </button>
+        </div>
+      </div>
+
+      {/* 에러 메시지 */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+          {error}
+        </div>
+      )}
+
+      {/* 콘서트 목록 */}
+      <div className="bg-white rounded-lg shadow-sm">
+        {loading ? (
+          <div className="p-8 text-center">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <p className="mt-2 text-gray-600">로딩 중...</p>
+          </div>
+        ) : concerts.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">
+            <Calendar size={48} className="mx-auto mb-4 text-gray-300" />
+            <p>등록된 콘서트가 없습니다.</p>
+            <button
+              onClick={() => setShowCreateModal(true)}
+              className="mt-4 text-blue-600 hover:text-blue-800"
+            >
+              첫 번째 콘서트를 등록해보세요
+            </button>
+          </div>
+        ) : (
+          <>
+            {/* 테이블 헤더 */}
+            <div className="border-b border-gray-200">
+              <div className="grid grid-cols-12 gap-4 p-4 text-sm font-medium text-gray-500">
+                <div className="col-span-3">
+                  <button
+                    onClick={() => handleSortChange('title')}
+                    className="flex items-center gap-1 hover:text-gray-700"
+                  >
+                    콘서트 정보
+                    {sorting.sortBy === 'title' && (
+                      <span>{sorting.sortDir === 'asc' ? '↑' : '↓'}</span>
+                    )}
+                  </button>
+                </div>
+                <div className="col-span-2">
+                  <button
+                    onClick={() => handleSortChange('concertDate')}
+                    className="flex items-center gap-1 hover:text-gray-700"
+                  >
+                    공연일시
+                    {sorting.sortBy === 'concertDate' && (
+                      <span>{sorting.sortDir === 'asc' ? '↑' : '↓'}</span>
+                    )}
+                  </button>
+                </div>
+                <div className="col-span-2">장소</div>
+                <div className="col-span-1">좌석수</div>
+                <div className="col-span-1">
+                  <button
+                    onClick={() => handleSortChange('status')}
+                    className="flex items-center gap-1 hover:text-gray-700"
+                  >
+                    상태
+                    {sorting.sortBy === 'status' && (
+                      <span>{sorting.sortDir === 'asc' ? '↑' : '↓'}</span>
+                    )}
+                  </button>
+                </div>
+                <div className="col-span-2">
+                  <button
+                    onClick={() => handleSortChange('createdAt')}
+                    className="flex items-center gap-1 hover:text-gray-700"
+                  >
+                    등록일
+                    {sorting.sortBy === 'createdAt' && (
+                      <span>{sorting.sortDir === 'asc' ? '↑' : '↓'}</span>
+                    )}
+                  </button>
+                </div>
+                <div className="col-span-1">작업</div>
+              </div>
+            </div>
+
+            {/* 콘서트 목록 */}
+            <div className="divide-y divide-gray-200">
+              {concerts.map((concert) => (
+                <div
+                  key={concert.concertId}
+                  className="grid grid-cols-12 gap-4 p-4 hover:bg-gray-50"
+                >
+                  {/* 콘서트 정보 */}
+                  <div className="col-span-3">
+                    <div className="flex items-start gap-3">
+                      <div className="w-12 h-12 bg-gray-200 rounded-lg flex items-center justify-center overflow-hidden">
+                        {concert.posterImageUrl ? (
+                          <img
+                            src={concert.posterImageUrl}
+                            alt={concert.title}
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <Image size={20} className="text-gray-400" />
+                        )}
+                      </div>
+                      <div>
+                        <h3 className="font-medium text-gray-900 line-clamp-2">
+                          {concert.title}
+                        </h3>
+                        <p className="text-sm text-gray-600">
+                          {concert.artist}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 공연일시 */}
+                  <div className="col-span-2">
+                    <div className="flex items-center gap-1 text-sm">
+                      <Calendar size={14} className="text-gray-400" />
+                      <span>{formatDate(concert.concertDate)}</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
+                      <Clock size={14} className="text-gray-400" />
+                      <span>
+                        {concert.startTime} - {concert.endTime}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* 장소 */}
+                  <div className="col-span-2">
+                    <div className="flex items-center gap-1 text-sm">
+                      <MapPin size={14} className="text-gray-400" />
+                      <span className="line-clamp-2">{concert.venueName}</span>
+                    </div>
+                  </div>
+
+                  {/* 좌석수 */}
+                  <div className="col-span-1">
+                    <div className="flex items-center gap-1 text-sm">
+                      <Users size={14} className="text-gray-400" />
+                      <span>{concert.totalSeats?.toLocaleString()}</span>
+                    </div>
+                  </div>
+
+                  {/* 상태 */}
+                  <div className="col-span-1">
+                    {getStatusBadge(concert.status)}
+                  </div>
+
+                  {/* 등록일 */}
+                  <div className="col-span-2">
+                    <span className="text-sm text-gray-600">
+                      {formatDateTime(concert.createdAt)}
+                    </span>
+                  </div>
+
+                  {/* 작업 버튼들 */}
+                  <div className="col-span-1">
+                    <div className="flex gap-1">
+                      <button
+                        onClick={() => {
+                          setSelectedConcert(concert);
+                          setShowEditModal(true);
+                        }}
+                        className="p-1 text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                        title="수정"
+                      >
+                        <Edit size={16} />
+                      </button>
+                      <button
+                        onClick={() => deleteConcert(concert.concertId)}
+                        className="p-1 text-red-600 hover:bg-red-50 rounded transition-colors"
+                        title="삭제"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* 페이지네이션 */}
+        {!loading && concerts.length > 0 && (
+          <div className="p-4 border-t border-gray-200">
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-gray-600">
+                총 {pagination.totalElements}개 중{' '}
+                {pagination.page * pagination.size + 1}-
+                {Math.min(
+                  (pagination.page + 1) * pagination.size,
+                  pagination.totalElements,
+                )}
+                개 표시
+              </div>
+
+              <div className="flex items-center gap-2">
+                {/* 페이지 크기 선택 */}
+                <select
+                  value={pagination.size}
+                  onChange={(e) => handleSizeChange(Number(e.target.value))}
+                  className="text-sm border border-gray-300 rounded px-2 py-1"
+                >
+                  <option value={10}>10개씩</option>
+                  <option value={20}>20개씩</option>
+                  <option value={50}>50개씩</option>
+                  <option value={100}>100개씩</option>
+                </select>
+
+                {/* 페이지 버튼들 */}
+                <div className="flex gap-1">
+                  <button
+                    onClick={() => handlePageChange(pagination.page - 1)}
+                    disabled={pagination.first}
+                    className="px-3 py-1 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    이전
+                  </button>
+
+                  {Array.from(
+                    { length: Math.min(5, pagination.totalPages) },
+                    (_, i) => {
+                      const pageNum = pagination.page + i - 2;
+                      if (pageNum < 0 || pageNum >= pagination.totalPages)
+                        return null;
+
+                      return (
+                        <button
+                          key={pageNum}
+                          onClick={() => handlePageChange(pageNum)}
+                          className={`px-3 py-1 text-sm border rounded ${
+                            pageNum === pagination.page
+                              ? 'bg-blue-600 text-white border-blue-600'
+                              : 'border-gray-300 hover:bg-gray-50'
+                          }`}
+                        >
+                          {pageNum + 1}
+                        </button>
+                      );
+                    },
+                  )}
+
+                  <button
+                    onClick={() => handlePageChange(pagination.page + 1)}
+                    disabled={pagination.last}
+                    className="px-3 py-1 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    다음
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 모달들은 추후 구현 */}
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg">
+            <h2 className="text-xl font-bold mb-4">콘서트 등록</h2>
+            <p>콘서트 등록 폼이 여기에 들어갑니다.</p>
+            <button
+              onClick={() => setShowCreateModal(false)}
+              className="mt-4 px-4 py-2 bg-gray-500 text-white rounded"
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showEditModal && selectedConcert && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg">
+            <h2 className="text-xl font-bold mb-4">콘서트 수정</h2>
+            <p>콘서트 수정 폼이 여기에 들어갑니다.</p>
+            <p>선택된 콘서트: {selectedConcert.title}</p>
+            <button
+              onClick={() => setShowEditModal(false)}
+              className="mt-4 px-4 py-2 bg-gray-500 text-white rounded"
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SellerConcertList;

--- a/src/shared/components/ui/Modal.jsx
+++ b/src/shared/components/ui/Modal.jsx
@@ -1,1 +1,168 @@
-//
+// src/shared/components/ui/Modal.jsx
+
+import React, { useEffect } from 'react';
+
+/**
+ * ===== Modal 컴포넌트 =====
+ *
+ * 재사용 가능한 모달 컴포넌트
+ * 리뷰 작성, 기대평 작성, 삭제 확인 등에 사용
+ */
+const Modal = ({
+  // ===== 필수 props =====
+  isOpen = false, // 모달 열림/닫힘 상태
+  onClose, // 모달 닫기 핸들러
+  children, // 모달 내용
+
+  // ===== 선택적 props =====
+  title = '', // 모달 제목
+  showCloseButton = true, // X 버튼 표시 여부
+  closeOnBackdrop = true, // 배경 클릭 시 닫기
+  closeOnEsc = true, // ESC 키로 닫기
+
+  // ===== 스타일 props =====
+  size = 'medium', // 'small' | 'medium' | 'large'
+  className = '', // 추가 CSS 클래스
+}) => {
+  // ESC 키 이벤트 처리
+  useEffect(() => {
+    if (!isOpen || !closeOnEsc) return;
+
+    const handleEscKey = (event) => {
+      if (event.key === 'Escape') {
+        onClose?.();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscKey);
+    return () => document.removeEventListener('keydown', handleEscKey);
+  }, [isOpen, closeOnEsc, onClose]);
+
+  // 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // 모달이 열려있지 않으면 렌더링하지 않음
+  if (!isOpen) return null;
+
+  // 배경 클릭 핸들러
+  const handleBackdropClick = (event) => {
+    if (closeOnBackdrop && event.target === event.currentTarget) {
+      onClose?.();
+    }
+  };
+
+  // 모달 크기별 스타일
+  const getSizeStyles = () => {
+    switch (size) {
+      case 'small':
+        return { maxWidth: '400px', width: '90vw' };
+      case 'large':
+        return { maxWidth: '800px', width: '90vw' };
+      case 'medium':
+      default:
+        return { maxWidth: '600px', width: '90vw' };
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+        padding: '20px',
+      }}
+      onClick={handleBackdropClick}
+      className={`modal-backdrop ${className}`}
+    >
+      <div
+        style={{
+          backgroundColor: '#ffffff',
+          borderRadius: '12px',
+          boxShadow:
+            '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+          maxHeight: '90vh',
+          overflow: 'auto',
+          position: 'relative',
+          ...getSizeStyles(),
+        }}
+        onClick={(e) => e.stopPropagation()}
+        className="modal-content"
+      >
+        {/* 모달 헤더 */}
+        {(title || showCloseButton) && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '20px 24px',
+              borderBottom: '1px solid #e5e7eb',
+            }}
+          >
+            {title && (
+              <h2
+                style={{
+                  fontSize: '18px',
+                  fontWeight: 'bold',
+                  color: '#1f2937',
+                  margin: 0,
+                }}
+              >
+                {title}
+              </h2>
+            )}
+            {showCloseButton && (
+              <button
+                onClick={onClose}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  fontSize: '24px',
+                  color: '#6b7280',
+                  cursor: 'pointer',
+                  padding: '4px',
+                  borderRadius: '4px',
+                  transition: 'color 0.2s ease',
+                }}
+                onMouseEnter={(e) => (e.target.style.color = '#374151')}
+                onMouseLeave={(e) => (e.target.style.color = '#6b7280')}
+                aria-label="모달 닫기"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* 모달 본문 */}
+        <div
+          style={{
+            padding: title || showCloseButton ? '24px' : '24px',
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
# 🛠️ [콘서트 관리] 리뷰/기대평 수정 기능 버그 수정 및 코드 포맷팅 적용

## 2. 작업 내용
* [x] **리뷰/기대평 수정 기능 버그 수정** (핵심 작업)
* [x] 사용자 권한 기반 수정/삭제 버튼 표시 구현
* [x] 모달을 통한 수정 폼 제공 및 데이터 바인딩 개선

## 3. 주요 변경사항

### 🔧 리뷰/기대평 수정 기능 수정
* **수정된 파일**:
  - `src/features/concert/components/ReviewForm.jsx`: 수정 모드 데이터 바인딩 개선
  - `src/features/concert/components/ExpectationForm.jsx`: 수정 모드 폼 데이터 처리 수정
  - `src/features/concert/components/ReviewList.jsx`: 작성자 권한 확인 및 수정/삭제 버튼 추가
  - `src/features/concert/components/ExpectationList.jsx`: 작성자 권한 확인 및 수정/삭제 버튼 추가
  - `src/pages/concert/ConcertDetailPage.jsx`: 수정/삭제 핸들러 구현 및 모달 연동

* **새로 추가된 파일**:
  - `src/shared/components/ui/Modal.jsx`: 재사용 가능한 모달 컴포넌트

## 4. 수정된 버그 상세

### 🐛 해결된 문제들
1. **리뷰 수정 시 기존 데이터가 폼에 로드되지 않는 문제**
   - `initialData` props 바인딩 로직 수정
   - `useEffect`를 통한 폼 데이터 초기화 개선

2. **기대평 수정 시 필드명 불일치 문제**
   - `setTouched` 필드명을 실제 폼 필드와 일치시킴
   - 유효성 검증 에러 표시가 정상 동작하도록 수정

3. **작성자가 아닌 사용자에게 수정/삭제 버튼이 표시되는 문제**
   - `currentUserId` props 추가하여 권한 확인 로직 구현
   - 조건부 렌더링으로 작성자만 버튼 표시

4. **수정 모드와 작성 모드 구분 문제**
   - `mode` props를 통한 명확한 모드 구분
   - 수정 시 기존 데이터 유지, 작성 시 빈 폼 제공

## 5. 보안 확인사항
* [x] **사용자 권한 확인**: 작성자만 수정/삭제 가능
* [x] **입력값 validation**: 실시간 유효성 검증 유지
* [x] **에러 핸들링**: try-catch 블록으로 안전성 확보

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 판매자를 위한 콘서트 등록 및 수정 폼이 추가되었습니다.
  * 판매자 콘서트 목록 관리 기능(정렬, 필터, 페이지네이션, 생성/수정/삭제)이 추가되었습니다.
  * 재사용 가능한 모달 컴포넌트가 도입되었습니다.

* **Bug Fixes**
  * 기대평 목록에서 작성자에게만 수정/삭제 버튼이 노출됩니다.

* **Refactor**
  * 여러 함수 및 콜백의 화살표 함수 매개변수 문법이 간소화되었습니다.
  * 코드 스타일 및 포맷팅 일관성이 개선되었습니다.

* **Chores**
  * 프론트엔드 CI 파이프라인 워크플로우가 제거되었습니다.
  * 코드 포매팅 관련 스크립트가 삭제되고 ESLint 플러그인이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->