### PR TITLE
[FIX] 마이페이지 예매 취소 API 경로 수정

### DIFF
--- a/src/features/user/services/userService.js
+++ b/src/features/user/services/userService.js
@@ -77,7 +77,6 @@ export const userService = {
             const response = await apiClient.post(
                 `/bookings/${bookingId}/cancel`,
             );
-            console.log(response);
             return response;
         } catch (error) {
             throw new Error(

--- a/src/features/user/services/userService.js
+++ b/src/features/user/services/userService.js
@@ -74,10 +74,11 @@ export const userService = {
 
     cancelBooking: async (bookingId) => {
         try {
-            const response = await apiClient.delete(
-                `/mypage/bookingDetail/cancel/${bookingId}`,
+            const response = await apiClient.post(
+                `/bookings/${bookingId}/cancel`,
             );
-            return response.data;
+            console.log(response);
+            return response;
         } catch (error) {
             throw new Error(
                 error.message || '예매 취소 중 오류가 발생했습니다.',


### PR DESCRIPTION
[FIX] 마이페이지 예매 취소 API 경로 수정
/mypage/bookingDetail/cancel/${bookingId} 
->
/bookings/${bookingId}/cancel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 예약 취소 시 요청 방식이 DELETE에서 POST로 변경되고 경로가 업데이트되어 더 안정적으로 처리됩니다.
* **기타**
  * 예약 취소 후 응답 정보가 더 상세하게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->